### PR TITLE
[REFACTOR] #27 - typeAuth, typeApi annotation 생성 후 연결

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,6 +4,7 @@
     <option name="filePathToZoomLevelMap">
       <map>
         <entry key="..\:/Users/Youngmu/Desktop/woowahan/android-repo-02/presentation/src/main/res/layout/activity_login.xml" value="0.12685185185185185" />
+        <entry key="..\:/Users/Youngmu/Desktop/woowahan/android-repo-02/presentation/src/main/res/layout/activity_main.xml" value="0.14688675302966986" />
         <entry key="presentation/src/main/res/drawable/bg_gradient.xml" value="0.3225" />
         <entry key="presentation/src/main/res/drawable/box_large_button.xml" value="0.3225" />
         <entry key="presentation/src/main/res/font/outfit.xml" value="0.35" />

--- a/presentation/src/main/java/com/woowahan/repositorysearch/di/module/DataSourceModule.kt
+++ b/presentation/src/main/java/com/woowahan/repositorysearch/di/module/DataSourceModule.kt
@@ -13,7 +13,8 @@ import javax.inject.Singleton
 object DataSourceModule {
     @Singleton
     @Provides
-    fun provideAuthDataSource(authService: AuthService): AuthDataSourceImpl {
+    @RetrofitModule.typeAuth
+    fun provideAuthDataSource(@RetrofitModule.typeAuth authService: AuthService): AuthDataSourceImpl {
         return AuthDataSourceImpl(authService)
     }
 }

--- a/presentation/src/main/java/com/woowahan/repositorysearch/di/module/RepositoryModule.kt
+++ b/presentation/src/main/java/com/woowahan/repositorysearch/di/module/RepositoryModule.kt
@@ -14,6 +14,7 @@ import javax.inject.Singleton
 object RepositoryModule {
     @Singleton
     @Provides
-    fun provideAuthRepository(authDataSourceImpl: AuthDataSourceImpl): AuthRepository =
+    @RetrofitModule.typeAuth
+    fun provideAuthRepository(@RetrofitModule.typeAuth authDataSourceImpl: AuthDataSourceImpl): AuthRepository =
         AuthRepositoryImpl(authDataSourceImpl)
 }

--- a/presentation/src/main/java/com/woowahan/repositorysearch/di/module/RetrofitModule.kt
+++ b/presentation/src/main/java/com/woowahan/repositorysearch/di/module/RetrofitModule.kt
@@ -1,6 +1,5 @@
 package com.woowahan.repositorysearch.di.module
 
-import com.woowahan.repositorysearch.util.TokenInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -15,8 +14,17 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object RetrofitModule {
+    @Qualifier
+    @Retention(AnnotationRetention.BINARY)
+    annotation class typeAuth
+
+    @Qualifier
+    @Retention(AnnotationRetention.BINARY)
+    annotation class typeApi
+
     @Provides
     @Singleton
+    @typeAuth
     fun provideAuthOkHttpClient(): OkHttpClient {
         return OkHttpClient.Builder()
             .addInterceptor(HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
@@ -25,7 +33,8 @@ object RetrofitModule {
 
     @Provides
     @Singleton
-    fun provideAuthRetrofit(okHttpClient: OkHttpClient): Retrofit {
+    @typeAuth
+    fun provideAuthRetrofit(@typeAuth okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
             .baseUrl("https://github.com")
             .addConverterFactory(GsonConverterFactory.create())

--- a/presentation/src/main/java/com/woowahan/repositorysearch/di/module/ServiceModule.kt
+++ b/presentation/src/main/java/com/woowahan/repositorysearch/di/module/ServiceModule.kt
@@ -6,7 +6,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
-import javax.inject.Qualifier
 import javax.inject.Singleton
 
 @Module
@@ -15,7 +14,8 @@ object ServiceModule {
 
     @Provides
     @Singleton
-    fun provideAuthService(retrofit: Retrofit): AuthService {
+    @RetrofitModule.typeAuth
+    fun provideAuthService(@RetrofitModule.typeAuth retrofit: Retrofit): AuthService {
         return retrofit.create(AuthService::class.java)
     }
 }

--- a/presentation/src/main/java/com/woowahan/repositorysearch/di/module/UseCaseModule.kt
+++ b/presentation/src/main/java/com/woowahan/repositorysearch/di/module/UseCaseModule.kt
@@ -13,7 +13,8 @@ import javax.inject.Singleton
 object UseCaseModule {
     @Singleton
     @Provides
-    fun provideGetGitHubAccessTokenUseCase(repository: AuthRepository): GetGitHubAccessTokenUseCase {
+    @RetrofitModule.typeAuth
+    fun provideGetGitHubAccessTokenUseCase(@RetrofitModule.typeAuth repository: AuthRepository): GetGitHubAccessTokenUseCase {
         return GetGitHubAccessTokenUseCase(repository)
     }
 }

--- a/presentation/src/main/java/com/woowahan/repositorysearch/ui/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/woowahan/repositorysearch/ui/login/LoginViewModel.kt
@@ -1,25 +1,21 @@
 package com.woowahan.repositorysearch.ui.login
 
-import android.content.Intent
-import android.widget.Toast
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woowahan.domain.authUseCase.GetGitHubAccessTokenUseCase
-import com.woowahan.domain.model.GitHubToken
 import com.woowahan.domain.model.GitToken
 import com.woowahan.repositorysearch.BuildConfig
-import com.woowahan.repositorysearch.ui.main.MainActivity
+import com.woowahan.repositorysearch.di.module.RetrofitModule
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.lang.Exception
 import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val getGitHubAccessTokenUseCase: GetGitHubAccessTokenUseCase
+    @RetrofitModule.typeAuth private val getGitHubAccessTokenUseCase: GetGitHubAccessTokenUseCase
 ) : ViewModel() {
     val SUCCESS = 1
     val FAIL = 2


### PR DESCRIPTION
## 개요
Github 로그인을 위한 retrofit, Github api 사용을 위한 retrofit 
총 2개의 retrofit 객체가 필요하다.

그래서 의존성 주입 시 사용할 의존객체를 선택하기 위해 @Qualifier로 typeAuth, typeApi annotation을 만들어서 주입했다.

## 구현 사항
- @typeAuth, @typeApi 생성
- 기존 로그인 Retrofit 관련 코드에 @typeAuth 명시