### PR TITLE
[REFACTOR] #53 - toModel()을 dataSource에서 호출

### DIFF
--- a/data/src/main/java/com/woowahan/data/auth/AuthDataSourceImpl.kt
+++ b/data/src/main/java/com/woowahan/data/auth/AuthDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.woowahan.data.auth
 
 import com.woowahan.data.base.BaseDataSource
 import com.woowahan.data.entity.GitHubTokenData
+import com.woowahan.data.entity.toModel
 import retrofit2.Response
 
 class AuthDataSourceImpl(override val service: AuthService) : BaseDataSource<AuthService>() {
@@ -9,5 +10,5 @@ class AuthDataSourceImpl(override val service: AuthService) : BaseDataSource<Aut
         clientId: String,
         clientSecret: String,
         code: String
-    ): GitHubTokenData = getData(service.getAccessToken(clientId, clientSecret, code))
+    ) = getData(service.getAccessToken(clientId, clientSecret, code)).toModel()
 }

--- a/data/src/main/java/com/woowahan/data/auth/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/woowahan/data/auth/AuthRepositoryImpl.kt
@@ -13,6 +13,6 @@ class AuthRepositoryImpl @Inject constructor(
         clientSecret: String,
         code: String
     ): GitHubToken {
-        return authDataSourceImpl.getAccessToken(clientId, clientSecret, code).toModel()
+        return authDataSourceImpl.getAccessToken(clientId, clientSecret, code)
     }
 }

--- a/data/src/main/java/com/woowahan/data/notification/NotificationDataSourceImpl.kt
+++ b/data/src/main/java/com/woowahan/data/notification/NotificationDataSourceImpl.kt
@@ -2,9 +2,13 @@ package com.woowahan.data.notification
 
 import com.woowahan.data.base.BaseDataSource
 import com.woowahan.data.entity.NotificationData
+import com.woowahan.data.entity.toModel
+import com.woowahan.domain.model.Notification
 
 class NotificationDataSourceImpl(override val service: NotificationService) :
     BaseDataSource<NotificationService>() {
-    suspend fun getNotifications(page: Int): List<NotificationData> =
-        getData(service.getNotifications(page))
+    suspend fun getNotifications(page: Int): List<Notification> =
+        getData(service.getNotifications(page)).map {
+            it.toModel()
+        }
 }

--- a/data/src/main/java/com/woowahan/data/notification/NotificationRepositoryImpl.kt
+++ b/data/src/main/java/com/woowahan/data/notification/NotificationRepositoryImpl.kt
@@ -17,7 +17,7 @@ class NotificationRepositoryImpl @Inject constructor(
         val result = ArrayList<Notification>()
 
         for (notificationData in notificationDatas) {
-            result.add(notificationData.toModel())
+            result.add(notificationData)
         }
 
         return result


### PR DESCRIPTION
## 개요
RepositoryImpl 에선 Domain data의 정보를 감추는게 좋을 것 같아서 DataSourceImpl에서 mapping 함